### PR TITLE
Multi desc

### DIFF
--- a/crates/bdk/src/types.rs
+++ b/crates/bdk/src/types.rs
@@ -156,13 +156,13 @@ impl Vbytes for usize {
 ///
 /// [`Wallet`]: crate::Wallet
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct LocalUtxo<K> {
+pub struct LocalUtxo {
     /// Reference to a transaction output
     pub outpoint: OutPoint,
     /// Transaction output
     pub txout: TxOut,
     /// Type of keychain
-    pub keychain: K,
+    //pub keychain: K,
     /// Whether this UTXO is spent or not
     pub is_spent: bool,
     /// The derivation index for the script pubkey in the wallet
@@ -173,21 +173,21 @@ pub struct LocalUtxo<K> {
 
 /// A [`Utxo`] with its `satisfaction_weight`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeightedUtxo<K> {
+pub struct WeightedUtxo {
     /// The weight of the witness data and `scriptSig` expressed in [weight units]. This is used to
     /// properly maintain the feerate when adding this input to a transaction during coin selection.
     ///
     /// [weight units]: https://en.bitcoin.it/wiki/Weight_units
     pub satisfaction_weight: usize,
     /// The UTXO
-    pub utxo: Utxo<K>,
+    pub utxo: Utxo,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// An unspent transaction output (UTXO).
-pub enum Utxo<K> {
+pub enum Utxo {
     /// A UTXO owned by the local wallet.
-    Local(LocalUtxo<K>),
+    Local(LocalUtxo),
     /// A UTXO owned by another wallet.
     Foreign {
         /// The location of the output.
@@ -198,7 +198,7 @@ pub enum Utxo<K> {
     },
 }
 
-impl<K> Utxo<K> {
+impl Utxo {
     /// Get the location of the UTXO
     pub fn outpoint(&self) -> OutPoint {
         match &self {

--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -118,7 +118,8 @@ impl FullyNodedExport {
     ) -> Result<Self, &'static str> {
         //TODO: handle the case where get_descriptor_for_keychain returns None
         let descriptor = wallet
-            .get_descriptor_for_keychain(KeychainKind::External).unwrap()
+            .get_descriptor_for_keychain(KeychainKind::External)
+            .unwrap()
             .to_string_with_secret(
                 &wallet
                     .get_signers(KeychainKind::External)
@@ -148,7 +149,8 @@ impl FullyNodedExport {
             true => {
                 //TODO: handle the case where get_descriptor_for_keychain returns None
                 let descriptor = wallet
-                    .get_descriptor_for_keychain(KeychainKind::Internal).unwrap()
+                    .get_descriptor_for_keychain(KeychainKind::Internal)
+                    .unwrap()
                     .to_string_with_secret(
                         &wallet
                             .get_signers(KeychainKind::Internal)


### PR DESCRIPTION
### Description

This attempts to solve the generic entanglement issue in TxBuilder while doing the generic Wallet. So far, it seems it's possible to use the existing TxBuilder by changing around some internal logic.

Different utxo types also should not depend on Keychain. So is coinselection algorithms. 

@vladimirfomene I have reverted those changes adding generic to the types. In general, we can't solve this mess by adding generics everywhere.

Lastly, the only function erroring is `TXBuilder::Finalize_tx()`, which calls on `wallet.create_tx()`, which is only defined for the default wallet. We need a generic `create_tx()` implementation to solve this, which we have to do anyway for the generic wallet to work. 

So I think the next phase of the work here can focus on that. 


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing